### PR TITLE
p2p: close topic handles, blobber: add slot actions

### DIFF
--- a/blobber/slot_actions.go
+++ b/blobber/slot_actions.go
@@ -1,12 +1,18 @@
 package blobber
 
 import (
+	"crypto/rand"
+	"fmt"
+	"time"
+
+	"github.com/marioevz/blobber/kzg"
 	"github.com/marioevz/blobber/p2p"
 	"github.com/pkg/errors"
 	blsu "github.com/protolambda/bls12-381-util"
 	beacon_common "github.com/protolambda/zrnt/eth2/beacon/common"
 	"github.com/protolambda/ztyp/tree"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/sirupsen/logrus"
 )
 
 type SlotAction interface {
@@ -73,9 +79,9 @@ func SignBlobs(blobs []*eth.BlobSidecar, blobSidecarDomain beacon_common.BLSDoma
 	return signedBlobs, nil
 }
 
-type DefaultSlotAction struct{}
+type Default struct{}
 
-func (dsa DefaultSlotAction) Execute(
+func (s Default) Execute(
 	testP2P *p2p.TestP2P,
 	beaconBlock *eth.BeaconBlockDeneb,
 	beaconBlockDomain beacon_common.BLSDomain,
@@ -108,9 +114,9 @@ func (dsa DefaultSlotAction) Execute(
 	return true, nil
 }
 
-type BroadcastBlobsBeforeBlockAction struct{}
+type BroadcastBlobsBeforeBlock struct{}
 
-func (dsa BroadcastBlobsBeforeBlockAction) Execute(
+func (s BroadcastBlobsBeforeBlock) Execute(
 	testP2P *p2p.TestP2P,
 	beaconBlock *eth.BeaconBlockDeneb,
 	beaconBlockDomain beacon_common.BLSDomain,
@@ -138,6 +144,179 @@ func (dsa BroadcastBlobsBeforeBlockAction) Execute(
 	// Broadcast the block
 	if err := testP2P.BroadcastSignedBeaconBlockDeneb(signedBlock); err != nil {
 		return false, errors.Wrap(err, "failed to broadcast signed beacon block")
+	}
+
+	return true, nil
+}
+
+type BlobGossipDelay struct {
+	DelayMilliseconds int `json:"delay_milliseconds"`
+}
+
+func (s BlobGossipDelay) Execute(
+	testP2P *p2p.TestP2P,
+	beaconBlock *eth.BeaconBlockDeneb,
+	beaconBlockDomain beacon_common.BLSDomain,
+	blobSidecars []*eth.BlobSidecar,
+	blobSidecarDomain beacon_common.BLSDomain,
+	proposerKey *[32]byte,
+) (bool, error) {
+	// Sign block and blobs
+	signedBlock, err := SignBlock(beaconBlock, beaconBlockDomain, proposerKey)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to sign block")
+	}
+	signedBlobs, err := SignBlobs(blobSidecars, blobSidecarDomain, proposerKey)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to sign blobs")
+	}
+
+	// Broadcast the block
+	if err := testP2P.BroadcastSignedBeaconBlockDeneb(signedBlock); err != nil {
+		return false, errors.Wrap(err, "failed to broadcast signed beacon block")
+	}
+
+	// Insert a delay before gossiping the blobs
+	time.Sleep(time.Duration(s.DelayMilliseconds) * time.Millisecond)
+
+	// Broadcast the blobs
+	for _, signedBlob := range signedBlobs {
+		if err := testP2P.BroadcastSignedBlobSidecar(signedBlob, nil); err != nil {
+			return false, errors.Wrap(err, "failed to broadcast signed blob sidecar")
+		}
+	}
+
+	return true, nil
+}
+
+// Things to try:
+// - Broadcast another blob with valid kzg or invalid kzg
+// - Broadcast before or after the valid blob list
+// - Broadcast the blobs before or after the block
+type ExtraBlobs struct {
+	IncorrectKZGCommitment  bool `json:"incorrect_kzg_commitment"`
+	IncorrectKZGProof       bool `json:"incorrect_kzg_proof"`
+	IncorrectBlockRoot      bool `json:"incorrect_block_root"`
+	DelayMilliseconds       int  `json:"delay_milliseconds"`
+	BroadcastBlockFirst     bool `json:"broadcast_block_last"`
+	BroadcastExtraBlobFirst bool `json:"broadcast_extra_blob_last"`
+}
+
+func FillSidecarWithRandomBlob(sidecar *eth.BlobSidecar) error {
+	blob, kgzCommitment, kzgProof, err := kzg.RandomBlob()
+	if err != nil {
+		return errors.Wrap(err, "failed to generate random blob")
+	}
+	sidecar.Blob = blob[:]
+	sidecar.KzgCommitment = kgzCommitment[:]
+	sidecar.KzgProof = kzgProof[:]
+	return nil
+}
+
+func (s ExtraBlobs) Execute(
+	testP2P *p2p.TestP2P,
+	beaconBlock *eth.BeaconBlockDeneb,
+	beaconBlockDomain beacon_common.BLSDomain,
+	blobSidecars []*eth.BlobSidecar,
+	blobSidecarDomain beacon_common.BLSDomain,
+	proposerKey *[32]byte,
+) (bool, error) {
+	// Sign block and blobs
+	signedBlock, err := SignBlock(beaconBlock, beaconBlockDomain, proposerKey)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to sign block")
+	}
+	signedBlobs, err := SignBlobs(blobSidecars, blobSidecarDomain, proposerKey)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to sign blobs")
+	}
+
+	// Generate the extra blob sidecar
+	extraBlobSidecar := &eth.BlobSidecar{
+		Slot:            beaconBlock.Slot,
+		BlockParentRoot: beaconBlock.ParentRoot[:],
+		ProposerIndex:   beaconBlock.ProposerIndex,
+	}
+
+	if s.IncorrectBlockRoot {
+		extraBlobSidecar.BlockRoot = make([]byte, 32)
+		rand.Read(extraBlobSidecar.BlockRoot)
+	} else {
+		blockRoot, err := beaconBlock.HashTreeRoot()
+		if err != nil {
+			return false, errors.Wrap(err, "failed to get block hash tree root")
+		}
+		extraBlobSidecar.BlockRoot = blockRoot[:]
+	}
+
+	if err := FillSidecarWithRandomBlob(extraBlobSidecar); err != nil {
+		return false, errors.Wrap(err, "failed to fill extra blob sidecar")
+	}
+
+	if s.IncorrectKZGCommitment {
+		rand.Read(extraBlobSidecar.KzgCommitment)
+	}
+
+	if s.IncorrectKZGProof {
+		rand.Read(extraBlobSidecar.KzgProof)
+	}
+
+	// Sign the blob
+	signedExtraBlob, err := SignBlob(extraBlobSidecar, blobSidecarDomain, proposerKey)
+	if err != nil {
+		return false, errors.Wrap(err, "failed to sign extra blob")
+	}
+
+	logrus.WithFields(
+		logrus.Fields{
+			"blockRoot":       fmt.Sprintf("%x", extraBlobSidecar.BlockRoot),
+			"blockParentRoot": fmt.Sprintf("%x", extraBlobSidecar.BlockParentRoot),
+			"slot":            extraBlobSidecar.Slot,
+			"proposerIndex":   extraBlobSidecar.ProposerIndex,
+			"kzgCommitment":   fmt.Sprintf("%x", extraBlobSidecar.KzgCommitment),
+			"kzgProof":        fmt.Sprintf("%x", extraBlobSidecar.KzgProof),
+		},
+	).Debug("Extra blob")
+
+	if s.BroadcastBlockFirst {
+		// Broadcast the block
+		if err := testP2P.BroadcastSignedBeaconBlockDeneb(signedBlock); err != nil {
+			return false, errors.Wrap(err, "failed to broadcast signed beacon block")
+		}
+	}
+
+	if s.BroadcastExtraBlobFirst {
+		// Broadcast the extra blob
+		if err := testP2P.BroadcastSignedBlobSidecar(signedExtraBlob, nil); err != nil {
+			return false, errors.Wrap(err, "failed to broadcast extra signed blob sidecar")
+		}
+
+		// Insert a delay before gossiping the blobs
+		time.Sleep(time.Duration(s.DelayMilliseconds) * time.Millisecond)
+	}
+
+	// Broadcast the correct blobs
+	for _, signedBlob := range signedBlobs {
+		if err := testP2P.BroadcastSignedBlobSidecar(signedBlob, nil); err != nil {
+			return false, errors.Wrap(err, "failed to broadcast signed blob sidecar")
+		}
+	}
+
+	if !s.BroadcastExtraBlobFirst {
+		// Insert a delay before gossiping the blobs
+		time.Sleep(time.Duration(s.DelayMilliseconds) * time.Millisecond)
+
+		// Broadcast the extra blob
+		if err := testP2P.BroadcastSignedBlobSidecar(signedExtraBlob, nil); err != nil {
+			return false, errors.Wrap(err, "failed to broadcast extra signed blob sidecar")
+		}
+	}
+
+	if !s.BroadcastBlockFirst {
+		// Broadcast the block
+		if err := testP2P.BroadcastSignedBeaconBlockDeneb(signedBlock); err != nil {
+			return false, errors.Wrap(err, "failed to broadcast signed beacon block")
+		}
 	}
 
 	return true, nil

--- a/kzg/blob_generator.go
+++ b/kzg/blob_generator.go
@@ -1,0 +1,109 @@
+package kzg
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"math/rand"
+	"sync"
+
+	gokzg4844 "github.com/crate-crypto/go-kzg-4844"
+	"github.com/pkg/errors"
+)
+
+var gCryptoCtx gokzg4844.Context
+var initCryptoCtx sync.Once
+
+// InitializeCryptoCtx initializes the global context object returned via CryptoCtx
+func InitializeCryptoCtx() {
+	initCryptoCtx.Do(func() {
+		// Initialize context to match the configurations that the
+		// specs are using.
+		ctx, err := gokzg4844.NewContext4096Insecure1337()
+		if err != nil {
+			panic(fmt.Sprintf("could not create context, err : %v", err))
+		}
+		gCryptoCtx = *ctx
+		// Initialize the precompile return value
+	})
+}
+
+// CryptoCtx returns a context object stores all of the necessary configurations
+// to allow one to create and verify blob proofs.
+// This function is expensive to run if the crypto context isn't initialized, so it is recommended to
+// pre-initialize by calling InitializeCryptoCtx
+func CryptoCtx() gokzg4844.Context {
+	InitializeCryptoCtx()
+	return gCryptoCtx
+}
+
+type BlobID uint64
+
+func (blobId BlobID) FillBlob(blob *gokzg4844.Blob) error {
+	if blob == nil {
+		return errors.New("blob is nil")
+	}
+	if blobId == 0 {
+		// Blob zero is empty blob, so leave as is
+		return nil
+	}
+	// Fill the blob with deterministic data
+	blobIdBytes := make([]byte, 8)
+	binary.BigEndian.PutUint64(blobIdBytes, uint64(blobId))
+
+	// First 32 bytes are the hash of the blob ID
+	currentHashed := sha256.Sum256(blobIdBytes)
+
+	for scalarIndex := 0; scalarIndex < gokzg4844.ScalarsPerBlob; scalarIndex++ {
+		copy(blob[scalarIndex*32:(scalarIndex+1)*32], currentHashed[:])
+
+		// Check that no 32 bytes chunks are greater than the BLS modulus
+		for i := 0; i < 32; i++ {
+			//blobByteIdx := ((scalarIndex + 1) * 32) - i - 1
+			blobByteIdx := (scalarIndex * 32) + i
+			if blob[blobByteIdx] < gokzg4844.BlsModulus[i] {
+				// go to next chunk
+				break
+			} else if blob[blobByteIdx] >= gokzg4844.BlsModulus[i] {
+				if gokzg4844.BlsModulus[i] > 0 {
+					// This chunk is greater than the modulus, and we can reduce it in this byte position
+					blob[blobByteIdx] = gokzg4844.BlsModulus[i] - 1
+					// go to next chunk
+					break
+				} else {
+					// This chunk is greater than the modulus, but we can't reduce it in this byte position, so we will try in the next byte position
+					blob[blobByteIdx] = gokzg4844.BlsModulus[i]
+				}
+			}
+		}
+
+		// Hash the current hash
+		currentHashed = sha256.Sum256(currentHashed[:])
+	}
+
+	return nil
+}
+
+func (blobId BlobID) GenerateBlob() (*gokzg4844.Blob, *gokzg4844.KZGCommitment, *gokzg4844.KZGProof, error) {
+	blob := gokzg4844.Blob{}
+	if err := blobId.FillBlob(&blob); err != nil {
+		return nil, nil, nil, errors.Wrap(err, "error filling blob")
+	}
+	ctx_4844 := CryptoCtx()
+
+	kzgCommitment, err := ctx_4844.BlobToKZGCommitment(blob, 0)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "error computing kzg commitment")
+	}
+
+	proof, err := ctx_4844.ComputeBlobKZGProof(gokzg4844.Blob(blob), kzgCommitment, 1)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "error computing kzg proof")
+	}
+
+	return &blob, &kzgCommitment, &proof, nil
+}
+
+func RandomBlob() (*gokzg4844.Blob, *gokzg4844.KZGCommitment, *gokzg4844.KZGProof, error) {
+	return BlobID(rand.Uint64()).GenerateBlob()
+}

--- a/p2p/broadcast.go
+++ b/p2p/broadcast.go
@@ -102,7 +102,7 @@ func (p *TestP2P) BroadcastSignedBeaconBlockDeneb(signedBeaconBlockDeneb *eth.Si
 	if err := PublishTopic(timeoutCtx, topicHandle, buf); err != nil {
 		return errors.Wrap(err, "failed to publish topic")
 	}
-	return nil
+	return topicHandle.Close()
 }
 
 func (p *TestP2P) BroadcastSignedBlobSidecar(signedBlobSidecar *eth.SignedBlobSidecar, subnet *uint64) error {
@@ -145,7 +145,7 @@ func (p *TestP2P) BroadcastSignedBlobSidecar(signedBlobSidecar *eth.SignedBlobSi
 	if err := PublishTopic(timeoutCtx, topicHandle, buf); err != nil {
 		return errors.Wrap(err, "failed to publish topic")
 	}
-	return nil
+	return topicHandle.Close()
 }
 
 func signedBeaconBlockToTopic(forkDigest [4]byte, protocolSuffix string) string {


### PR DESCRIPTION
## Changes Included
- p2p: The topic handles are closed after a single use now, and this allows sending multiple pubsub messages per topic in a single go.
  - Why not reuse? The topic handle is tied to a message ID unfortunately and each message ID is different depending on the contents
- blobber: Add slot actions, which are behavior customizations for each slot when gossiping the block and blobs, and can be tuned to be executed each slot or less frequently.