### PR TITLE
Add deploy image

### DIFF
--- a/.github/workflows/test-build-push.yaml
+++ b/.github/workflows/test-build-push.yaml
@@ -41,3 +41,40 @@ jobs:
       run: go test -v ./...
     - name: Build
       run: go build -v ./cmd/blobber.go
+
+  build-push:
+    name: build-push
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ethpandaops/blobber
+          flavor: latest=true
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: docker-build-push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          push: true
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Removed goarch def so that crosscompile stuff works as expected, we also have mac arm builders where its easier if we don't specify this field