### PR TITLE
blobber: Add multi testp2p, slot_actions: Add conflicting blobs action

### DIFF
--- a/p2p/broadcast.go
+++ b/p2p/broadcast.go
@@ -105,6 +105,15 @@ func (p *TestP2P) BroadcastSignedBeaconBlockDeneb(signedBeaconBlockDeneb *eth.Si
 	return topicHandle.Close()
 }
 
+func (p TestP2Ps) BroadcastSignedBeaconBlockDeneb(signedBeaconBlockDeneb *eth.SignedBeaconBlockDeneb) error {
+	for _, p2p := range p {
+		if err := p2p.BroadcastSignedBeaconBlockDeneb(signedBeaconBlockDeneb); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (p *TestP2P) BroadcastSignedBlobSidecar(signedBlobSidecar *eth.SignedBlobSidecar, subnet *uint64) error {
 	timeoutCtx, cancel := context.WithTimeout(p.ctx, time.Second)
 	defer cancel()
@@ -146,6 +155,15 @@ func (p *TestP2P) BroadcastSignedBlobSidecar(signedBlobSidecar *eth.SignedBlobSi
 		return errors.Wrap(err, "failed to publish topic")
 	}
 	return topicHandle.Close()
+}
+
+func (p TestP2Ps) BroadcastSignedBlobSidecar(signedBlobSidecar *eth.SignedBlobSidecar, subnet *uint64) error {
+	for _, p2p := range p {
+		if err := p2p.BroadcastSignedBlobSidecar(signedBlobSidecar, subnet); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func signedBeaconBlockToTopic(forkDigest [4]byte, protocolSuffix string) string {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -58,6 +58,8 @@ type TestP2P struct {
 	state    *common.Status
 }
 
+type TestP2Ps []*TestP2P
+
 func createLocalNode(
 	privKey *ecdsa.PrivateKey,
 	ipAddr net.IP,
@@ -236,6 +238,15 @@ func (p *TestP2P) Close() error {
 	}
 	defer p.cancel()
 	return p.Host.Close()
+}
+
+func (pl TestP2Ps) Close() error {
+	for _, p := range pl {
+		if err := p.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (p *TestP2P) WaitForP2PConnection(ctx context.Context) error {


### PR DESCRIPTION
## Changes Included
- Adds ability to create multiple testp2p instances to connect to different clients each and broadcast different messages to different beacon nodes
- Adds conflicting blobs test, where we broadcast a correct blob (whose kzg is included in the signed beacon block) to some of the peers and an incorrect (but correctly signed) blob to the rest of the peers, clients will ignore this extra blob, but then should sync and the chain must continue without disruption