### PR TITLE
feat: Add always-error-on-validator-response option

### DIFF
--- a/blobber.go
+++ b/blobber.go
@@ -132,7 +132,9 @@ func (b *Blobber) AddBeaconClient(cl *beacon_client.BeaconClient) *validator_pro
 		map[string]validator_proxy.ResponseCallback{
 			"/eth/v2/validator/blocks/{slot}": b.genValidatorBlockHandler(cl, id, 2),
 			"/eth/v3/validator/blocks/{slot}": b.genValidatorBlockHandler(cl, id, 3),
-		})
+		},
+		b.cfg.AlwaysErrorValidatorResponse,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -14,17 +14,18 @@ import (
 type Config struct {
 	sync.Mutex
 
-	ID                     int
-	Port                   int
-	ProxiesPortStart       int
-	Host                   string
-	Spec                   *beacon.Spec
-	ExternalIP             net.IP
-	BeaconGenesisTime      beacon.Timestamp
-	GenesisValidatorsRoot  tree.Root
-	ValidatorKeys          map[beacon.ValidatorIndex]*ValidatorKey
-	ValidatorKeysList      []*ValidatorKey
-	MaxDevP2PSessionReuses int
+	ID                           int
+	Port                         int
+	ProxiesPortStart             int
+	Host                         string
+	Spec                         *beacon.Spec
+	ExternalIP                   net.IP
+	BeaconGenesisTime            beacon.Timestamp
+	GenesisValidatorsRoot        tree.Root
+	ValidatorKeys                map[beacon.ValidatorIndex]*ValidatorKey
+	ValidatorKeysList            []*ValidatorKey
+	MaxDevP2PSessionReuses       int
+	AlwaysErrorValidatorResponse bool
 
 	SlotAction          slot_actions.SlotAction
 	SlotActionFrequency uint64
@@ -231,5 +232,17 @@ func WithSlotActionFrequency(freq uint64) Option {
 			return nil
 		},
 		description: fmt.Sprintf("WithSlotActionFrequency(%d)", freq),
+	}
+}
+
+func WithAlwaysErrorValidatorResponse() Option {
+	return Option{
+		apply: func(cfg *Config) error {
+			cfg.Lock()
+			defer cfg.Unlock()
+			cfg.AlwaysErrorValidatorResponse = true
+			return nil
+		},
+		description: fmt.Sprintf("WithAlwaysErrorValidatorResponse()"),
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/libp2p/go-libp2p v0.27.8
 	github.com/libp2p/go-libp2p-pubsub v0.9.3
-	github.com/marioevz/eth-clients v0.0.0-20230522233947-def6b7ee1b42
+	github.com/marioevz/eth-clients v0.0.0-20231012191302-f85f98699640
 	github.com/multiformats/go-multiaddr v0.9.0
 	github.com/pkg/errors v0.9.1
 	github.com/protolambda/bls12-381-util v0.0.0-20220416220906-d8552aa452c7

--- a/go.sum
+++ b/go.sum
@@ -154,6 +154,7 @@ github.com/cockroachdb/pebble v0.0.0-20230906160148-46873a6a7a06 h1:T+Np/xtzIjYM
 github.com/cockroachdb/pebble v0.0.0-20230906160148-46873a6a7a06/go.mod h1:bynZ3gvVyhlvjLI7PT6dmZ7g76xzJ7HpxfjgkzCGz6s=
 github.com/cockroachdb/redact v1.1.3 h1:AKZds10rFSIj7qADf0g46UixK8NNLwWTNdCIGS5wfSQ=
 github.com/cockroachdb/redact v1.1.3/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
+github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2/go.mod h1:8BT+cPK6xvFOcRlk0R8eg+OTkcqI6baNH4xAkpiYVvQ=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/consensys/bavard v0.1.13 h1:oLhMLOFGTLdlda/kma4VOJazblc7IM5y5QPd2A/YjhQ=
@@ -190,6 +191,7 @@ github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6Uh
 github.com/deckarep/golang-set/v2 v2.1.0 h1:g47V4Or+DUdzbs8FxCCmgb6VYd+ptPAngjM6dtGktsI=
 github.com/deckarep/golang-set/v2 v2.1.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=
+github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 h1:HbphB4TFFXpv7MNrT52FGrrgVXF1owhMVTHFZIlnvd4=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0/go.mod h1:DZGJHZMqrU4JJqFAWUS2UO1+lbSKsdiOoYi9Zzey7Fc=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
@@ -277,6 +279,7 @@ github.com/go-kit/kit v0.10.0/go.mod h1:xUsJbQ/Fp4kEt7AFgCuvyX4a71u8h9jB8tj/ORgO
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG1KdI/P7A=
+github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -618,6 +621,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/marioevz/eth-clients v0.0.0-20230522233947-def6b7ee1b42 h1:dVJl/m3X6vRz2tC5xsXOMaQwUj4bg1KQZRa7HXrG1lY=
 github.com/marioevz/eth-clients v0.0.0-20230522233947-def6b7ee1b42/go.mod h1:LnzXFKyMw3wF/3eaTfPhKiwkWkZJXokOWcUI02Ioi4s=
+github.com/marioevz/eth-clients v0.0.0-20231012191302-f85f98699640 h1:xHLAjLkQlO/Wh/Fmr740s+rXGxaYBdTbr5s7FWgwtiQ=
+github.com/marioevz/eth-clients v0.0.0-20231012191302-f85f98699640/go.mod h1:YVrdn57Q3rAzm3wus4T9tg1vMPca4csVbzorPhkGCW0=
 github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033 h1:sn57n+lbJrLS8FKYs08W7TEzraTGOCQGrSC4hni6rYw=
 github.com/marioevz/eth2api v0.0.0-20230922201437-72bd1301e033/go.mod h1:hcwWCT4sF1X7KsMZ535MvDZVk5M20Uyj+x2LARZjQsM=
 github.com/marioevz/zrnt v0.26.2-0.20230927204959-21993eae2d9f h1:pXAUGkBHJVQ2OH8SDFi26HYgJYcFJ8As+o+Gn7ASuCY=


### PR DESCRIPTION
## Changes Included
- Adds an option to always return an error to the validator on proposals, regardless of whether the blobber was able to sign and broadcast the block or not, which is helpful to detect and fail tests where the blobber is not properly working.
- Updates https://github.com/marioevz/eth-clients