### PR TITLE
feat: Deterministic Peer IDs

### DIFF
--- a/blobber.go
+++ b/blobber.go
@@ -183,7 +183,7 @@ func (b *Blobber) getTestP2P(count int) (p2p.TestP2Ps, error) {
 	var testP2Ps p2p.TestP2Ps
 
 	if b.lastTestP2P != nil {
-		if b.testP2PUses >= b.cfg.MaxDevP2PSessionReuses || len(b.lastTestP2P) != count {
+		if (b.cfg.MaxDevP2PSessionReuses > 0 && b.testP2PUses >= b.cfg.MaxDevP2PSessionReuses) || len(b.lastTestP2P) != count {
 			// Close the last one
 			b.lastTestP2P.Close()
 			b.lastTestP2P = nil

--- a/cmd/blobber.go
+++ b/cmd/blobber.go
@@ -57,6 +57,7 @@ func main() {
 		slotActionJson           string
 		slotActionFrequency      int
 		validatorProxyPortStart  int
+		maxDevP2PSessionReuses   int
 	)
 
 	flag.Var(
@@ -105,6 +106,12 @@ func main() {
 		"slot-action-frequency",
 		1,
 		"Frequency of slot actions in slots. 1 means execute every slot, 2 means execute every other slot, etc.",
+	)
+	flag.IntVar(
+		&maxDevP2PSessionReuses,
+		"max-dev-p2p-session-reuses",
+		0,
+		"Maximum number of times to reuse a DevP2P session, which results in a new PeerID. 0 means always use the same session.",
 	)
 	flag.StringVar(
 		&logLevel,
@@ -174,6 +181,7 @@ func main() {
 		config.WithValidatorKeysListFromFile(validatorKeyFilePath),
 		config.WithProxiesPortStart(validatorProxyPortStart),
 		config.WithSlotActionFrequency(uint64(slotActionFrequency)),
+		config.WithMaxDevP2PSessionReuses(maxDevP2PSessionReuses),
 		config.WithLogLevel(logLevel),
 	}
 

--- a/cmd/blobber.go
+++ b/cmd/blobber.go
@@ -58,6 +58,7 @@ func main() {
 		slotActionFrequency      int
 		validatorProxyPortStart  int
 		maxDevP2PSessionReuses   int
+		blobberID                uint64
 	)
 
 	flag.Var(
@@ -112,6 +113,12 @@ func main() {
 		"max-dev-p2p-session-reuses",
 		0,
 		"Maximum number of times to reuse a DevP2P session, which results in a new PeerID. 0 means always use the same session.",
+	)
+	flag.Uint64Var(
+		&blobberID,
+		"id",
+		0,
+		"Sets the blobber ID for this instance, it affects the PeerIDs that will be generated during runtime.",
 	)
 	flag.StringVar(
 		&logLevel,
@@ -175,6 +182,7 @@ func main() {
 	blobberOpts := []config.Option{
 		config.WithHost(hostIP),
 		config.WithExternalIP(net.ParseIP(externalIP)),
+		config.WithID(blobberID),
 		config.WithSpec(beaconClients[0].Config.Spec),
 		config.WithBeaconGenesisTime(*beaconClients[0].Config.GenesisTime),
 		config.WithGenesisValidatorsRoot(*beaconClients[0].Config.GenesisValidatorsRoot),

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"sync"
 
+	"github.com/marioevz/blobber/p2p"
 	"github.com/marioevz/blobber/slot_actions"
 	beacon "github.com/protolambda/zrnt/eth2/beacon/common"
 	"github.com/protolambda/ztyp/tree"
@@ -14,7 +15,7 @@ import (
 type Config struct {
 	sync.Mutex
 
-	ID                           int
+	ID                           uint64
 	Port                         int
 	ProxiesPortStart             int
 	Host                         string
@@ -49,11 +50,12 @@ func (o Option) MarshalText() ([]byte, error) {
 	return []byte(o.description), nil
 }
 
-func WithID(id int) Option {
+func WithID(id uint64) Option {
 	return Option{
 		apply: func(cfg *Config) error {
 			cfg.Lock()
 			defer cfg.Unlock()
+			p2p.SetInstanceID(id)
 			cfg.ID = id
 			return nil
 		},

--- a/p2p/broadcast.go
+++ b/p2p/broadcast.go
@@ -40,7 +40,7 @@ func PublishTopic(ctx context.Context, topicHandle *pubsub.Topic, data []byte, o
 		}
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return errors.Wrap(ctx.Err(), "topic list of peers was always empty")
 		case <-time.After(1 * time.Millisecond):
 		}
 	}
@@ -92,6 +92,7 @@ func (p *TestP2P) BroadcastSignedBeaconBlockDeneb(signedBeaconBlockDeneb *eth.Si
 		return errors.Wrap(err, "failed to get block hash tree root")
 	}
 	logrus.WithFields(logrus.Fields{
+		"id":         p.ID,
 		"topic":      topic,
 		"block_root": fmt.Sprintf("%x", blockRoot),
 		"slot":       signedBeaconBlockDeneb.Block.Slot,
@@ -142,6 +143,7 @@ func (p *TestP2P) BroadcastSignedBlobSidecar(signedBlobSidecar *eth.SignedBlobSi
 		return errors.Wrap(err, "failed to join topic")
 	}
 	logrus.WithFields(logrus.Fields{
+		"id":             p.ID,
 		"topic":          topic,
 		"block_root":     fmt.Sprintf("%x", signedBlobSidecar.Message.BlockRoot),
 		"index":          signedBlobSidecar.Message.Index,

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -34,6 +34,7 @@ import (
 
 var sszNetworkEncoder = encoder.SszNetworkEncoder{}
 var testP2PCounter = atomic.Uint64{}
+var instanceID = uint64(0)
 
 type Goodbye = primitives.SSZUint64
 type PingData = primitives.SSZUint64
@@ -47,6 +48,10 @@ const (
 
 const pubsubQueueSize = 600
 
+func SetInstanceID(id uint64) {
+	instanceID = id
+}
+
 type TestP2PID uint64
 
 func (id TestP2PID) String() string {
@@ -57,6 +62,7 @@ func (id TestP2PID) Keys() (crypto.PrivKey, crypto.PubKey) {
 	// Private keys are deterministic for testing purposes.
 	privKeyBytes := make([]byte, 32)
 	copy(privKeyBytes[:], []byte("blobber"))
+	binary.BigEndian.PutUint64(privKeyBytes[16:24], uint64(instanceID))
 	binary.BigEndian.PutUint64(privKeyBytes[24:], uint64(id))
 	priv, err := crypto.UnmarshalSecp256k1PrivateKey(privKeyBytes)
 	if err != nil {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -62,7 +62,7 @@ func (id TestP2PID) Keys() (crypto.PrivKey, crypto.PubKey) {
 	// Private keys are deterministic for testing purposes.
 	privKeyBytes := make([]byte, 32)
 	copy(privKeyBytes[:], []byte("blobber"))
-	binary.BigEndian.PutUint64(privKeyBytes[16:24], uint64(instanceID))
+	binary.BigEndian.PutUint64(privKeyBytes[16:24], instanceID)
 	binary.BigEndian.PutUint64(privKeyBytes[24:], uint64(id))
 	priv, err := crypto.UnmarshalSecp256k1PrivateKey(privKeyBytes)
 	if err != nil {

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -26,3 +26,38 @@ func TestTypesEncoding(t *testing.T) {
 		t.Fatalf("failed to encode metadata: %v", err)
 	}
 }
+
+func TestDeterministicPeerIDs(t *testing.T) {
+	for _, s := range []struct {
+		id        p2p.TestP2PID
+		expPeerID string
+	}{
+		{
+			id:        p2p.TestP2PID(1),
+			expPeerID: "16Uiu2HAm2DyWWCgyB9vyRg1WEyrLBhTxCpZrpq1iYXBtiZwdcDSe",
+		},
+		{
+			id:        p2p.TestP2PID(2),
+			expPeerID: "16Uiu2HAm9L7BLw3kqF6nLUJVHo2KQrc4qRZkMWfF55Fn4zaFDEQ6",
+		},
+		{
+			id:        p2p.TestP2PID(3),
+			expPeerID: "16Uiu2HAmH2eD6zmU2BEyUz3kJaN89zhfAENYw68Jmh3XwP1s1VvB",
+		},
+		{
+			id:        p2p.TestP2PID(4),
+			expPeerID: "16Uiu2HAkxTEdRWDFi3snqrsn47io7m8URPoxPgPwgBFZPexjUf5P",
+		},
+		{
+			id:        p2p.TestP2PID(5),
+			expPeerID: "16Uiu2HAmTUnRa3oDa7K1psWS21qxJJfC1uzmHxnxsF3Hrfv4H9R2",
+		},
+	} {
+		t.Run(s.expPeerID, func(t *testing.T) {
+			peerID := s.id.PeerID()
+			if peerID != s.expPeerID {
+				t.Fatalf("expected peer ID %s, got %s", s.expPeerID, peerID)
+			}
+		})
+	}
+}

--- a/p2p/p2p_test.go
+++ b/p2p/p2p_test.go
@@ -28,6 +28,7 @@ func TestTypesEncoding(t *testing.T) {
 }
 
 func TestDeterministicPeerIDs(t *testing.T) {
+	// Default blobber ID: 0
 	for _, s := range []struct {
 		id        p2p.TestP2PID
 		expPeerID string
@@ -51,6 +52,41 @@ func TestDeterministicPeerIDs(t *testing.T) {
 		{
 			id:        p2p.TestP2PID(5),
 			expPeerID: "16Uiu2HAmTUnRa3oDa7K1psWS21qxJJfC1uzmHxnxsF3Hrfv4H9R2",
+		},
+	} {
+		t.Run(s.expPeerID, func(t *testing.T) {
+			peerID := s.id.PeerID()
+			if peerID != s.expPeerID {
+				t.Fatalf("expected peer ID %s, got %s", s.expPeerID, peerID)
+			}
+		})
+	}
+
+	// Change blobber ID: 1
+	p2p.SetInstanceID(1)
+	for _, s := range []struct {
+		id        p2p.TestP2PID
+		expPeerID string
+	}{
+		{
+			id:        p2p.TestP2PID(1),
+			expPeerID: "16Uiu2HAmQoEwGBgsACp67cCAXNjCQBkHRVqtwBK2Sq1jcsyc154U",
+		},
+		{
+			id:        p2p.TestP2PID(2),
+			expPeerID: "16Uiu2HAmKfnranVvseqy1BYDfbXbMs2FuYKbbf6hL3r77CcWTwMH",
+		},
+		{
+			id:        p2p.TestP2PID(3),
+			expPeerID: "16Uiu2HAmKWFFj9a2JDBR595rFyKDZEXer5PppgkXNG5ESGCXoA8m",
+		},
+		{
+			id:        p2p.TestP2PID(4),
+			expPeerID: "16Uiu2HAm4ebhKMsRLTUmJ5REdXjPWpZ69JmUsMKjn9MhTNAU3yve",
+		},
+		{
+			id:        p2p.TestP2PID(5),
+			expPeerID: "16Uiu2HAm2BjMuoccupkyzif1rBVv1wMXdV7fKTRh2UFgceApuhei",
 		},
 	} {
 		t.Run(s.expPeerID, func(t *testing.T) {


### PR DESCRIPTION
## Changes Included
- Adds deterministic Peer IDs, and the ability to only use a single Peer ID throughout the blobber lifespan
- Adds option to change an "instance" ID number (parameter `--id`) which affects the deterministically generated Peer IDs, in case there are two or more blobbers running in the same network.

For instance 0, the default PeerIDs generated are:
1) `16Uiu2HAmQoEwGBgsACp67cCAXNjCQBkHRVqtwBK2Sq1jcsyc154U`
2) `16Uiu2HAmKfnranVvseqy1BYDfbXbMs2FuYKbbf6hL3r77CcWTwMH`
3) `16Uiu2HAmKWFFj9a2JDBR595rFyKDZEXer5PppgkXNG5ESGCXoA8m`
4) `16Uiu2HAm4ebhKMsRLTUmJ5REdXjPWpZ69JmUsMKjn9MhTNAU3yve`
5) `16Uiu2HAm2BjMuoccupkyzif1rBVv1wMXdV7fKTRh2UFgceApuhei`

These can be added to the list of trusted peers of each client to guarantee they will listen to the blobber messages.