### PR TITLE
config: add parameter to set the port of the beacon test p2p clients

### DIFF
--- a/blobber.go
+++ b/blobber.go
@@ -91,6 +91,9 @@ func NewBlobber(ctx context.Context, opts ...config.Option) (*Blobber, error) {
 	if b.ExternalIP == nil {
 		return nil, fmt.Errorf("no external ip configured")
 	}
+	if b.BeaconPortStart == 0 {
+		b.BeaconPortStart = PortBeaconTCP
+	}
 
 	// Create the fork decoder
 	b.forkDecoder = beacon.NewForkDecoder(b.Spec, b.GenesisValidatorsRoot)

--- a/cmd/blobber.go
+++ b/cmd/blobber.go
@@ -102,7 +102,7 @@ func main() {
 		&beaconPortStart,
 		"beacon-port-start",
 		9_000,
-		"Port number to start the beacon test p2p clients from. For each beacon node added, there will be one extra port used",
+		"Port number to start the beacon gossip p2p listen port from. For each beacon node added, there will be one extra port used",
 	)
 	flag.IntVar(
 		&validatorProxyPortStart,

--- a/cmd/blobber.go
+++ b/cmd/blobber.go
@@ -57,6 +57,7 @@ func main() {
 		validatorKeyFolderPath   string
 		slotActionJson           string
 		slotActionFrequency      int
+		beaconPortStart          int
 		validatorProxyPortStart  int
 		maxDevP2PSessionReuses   int
 		blobberID                uint64
@@ -96,6 +97,12 @@ func main() {
 		"client-init-timeout",
 		60,
 		"clients initialization wait timeout in seconds",
+	)
+	flag.IntVar(
+		&beaconPortStart,
+		"beacon-port-start",
+		9_000,
+		"Port number to start the beacon test p2p clients from. For each beacon node added, there will be one extra port used",
 	)
 	flag.IntVar(
 		&validatorProxyPortStart,
@@ -193,6 +200,7 @@ func main() {
 		config.WithSpec(beaconClients[0].Config.Spec),
 		config.WithBeaconGenesisTime(*beaconClients[0].Config.GenesisTime),
 		config.WithGenesisValidatorsRoot(*beaconClients[0].Config.GenesisValidatorsRoot),
+		config.WithBeaconPortStart(beaconPortStart),
 		config.WithProxiesPortStart(validatorProxyPortStart),
 		config.WithSlotActionFrequency(uint64(slotActionFrequency)),
 		config.WithMaxDevP2PSessionReuses(maxDevP2PSessionReuses),

--- a/config/config.go
+++ b/config/config.go
@@ -101,6 +101,18 @@ func WithPort(port int) Option {
 	}
 }
 
+func WithBeaconPortStart(port int) Option {
+	return Option{
+		apply: func(cfg *Config) error {
+			cfg.Lock()
+			defer cfg.Unlock()
+			cfg.TestP2P.BeaconPortStart = int64(port)
+			return nil
+		},
+		description: fmt.Sprintf("WithBeaconPortStart(%d)", port),
+	}
+}
+
 func WithLogLevel(level string) Option {
 	return Option{
 		apply: func(_ *Config) error {

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -46,10 +46,6 @@ const (
 
 const pubsubQueueSize = 600
 
-const (
-	PortBeaconTCP = 9000
-)
-
 type TestP2P struct {
 	InstanceID  uint64
 	peerCounter atomic.Uint64
@@ -61,6 +57,7 @@ type TestP2P struct {
 
 	// Config
 	ExternalIP             net.IP
+	BeaconPortStart        int64
 	MaxDevP2PSessionReuses int
 }
 
@@ -178,7 +175,7 @@ func (t *TestP2P) GetTestPeer(ctx context.Context, count int) (TestPeers, error)
 		// Generate a new one
 		testPeers = make(TestPeers, 0)
 		for i := 0; i < count; i++ {
-			testPeer, err := t.NewTestPeer(ctx, int64(PortBeaconTCP+i))
+			testPeer, err := t.NewTestPeer(ctx, t.BeaconPortStart+int64(i))
 			if err != nil {
 				// close the ones we actually created
 				testPeers.Close()


### PR DESCRIPTION
## Changes Included
- Adds a parameter to specify the starting port to be used by the test devp2p clients spawned in the blobber