### PR TITLE
slot_actions: Add config to corrupt more blobs

### DIFF
--- a/slot_actions/slot_actions.go
+++ b/slot_actions/slot_actions.go
@@ -445,8 +445,8 @@ func (s ConflictingBlobs) Execute(
 
 	// Create the second list of sidecars
 	secondBlobSidecarsLength := len(signedBlobs)
-	if secondBlobSidecarsLength < int(conflictingBlobsCount) {
-		secondBlobSidecarsLength = int(conflictingBlobsCount)
+	if secondBlobSidecarsLength < conflictingBlobsCount {
+		secondBlobSidecarsLength = conflictingBlobsCount
 	}
 	secondBlobSidecars := make([]*eth.SignedBlobSidecar, secondBlobSidecarsLength)
 

--- a/slot_actions/slot_actions_test.go
+++ b/slot_actions/slot_actions_test.go
@@ -34,4 +34,24 @@ func TestSlotActionsJsonParsing(t *testing.T) {
 			t.Fatalf("UnmarshallSlotAction() incorrect_kzg_commitment = %t", extraBlobs.IncorrectKZGCommitment)
 		}
 	}
+	jsonString = `{
+		"name": "conflicting_blobs",
+		"conflicting_blobs_count": 6,
+		"alternate_blob_recipients": true
+	}
+	`
+	act, err = slot_actions.UnmarshallSlotAction([]byte(jsonString))
+	if err != nil {
+		t.Fatalf("UnmarshallSlotAction() error = %v", err)
+	}
+	if conflictingBlobs, ok := act.(*slot_actions.ConflictingBlobs); !ok {
+		t.Fatalf("UnmarshallSlotAction() wrong type = %t", act)
+	} else {
+		if conflictingBlobs.ConflictingBlobsCount != 6 {
+			t.Fatalf("UnmarshallSlotAction() conflicting_blobs_count = %d", conflictingBlobs.ConflictingBlobsCount)
+		}
+		if conflictingBlobs.AlternateBlobRecipients != true {
+			t.Fatalf("UnmarshallSlotAction() alternate_blob_recipients = %t", conflictingBlobs.AlternateBlobRecipients)
+		}
+	}
 }


### PR DESCRIPTION
## Changes included
- Adds two more options to the `conflicting_blobs` test strategy:
  - `conflicting_blobs_count`: Send up to `MAX_BLOBS_PER_BLOCK` of conflicting blobs instead of only 1
  - `alternate_blob_recipients`: Alternate the test p2p sender of the conflicting blobs depending on the slot number