### PR TITLE
feat: Add incorrect index slot action

### DIFF
--- a/blobber.go
+++ b/blobber.go
@@ -293,12 +293,6 @@ func (b *Blobber) executeSlotActions(trigger_cl *beacon_client.BeaconClient, blR
 	if err != nil {
 		return false, errors.Wrap(err, "failed to get block hash tree root")
 	}
-	logrus.WithFields(logrus.Fields{
-		"slot":              blResponse.Block.Slot,
-		"block_root":        fmt.Sprintf("%x", blockRoot),
-		"parent_block_root": fmt.Sprintf("%x", blResponse.Block.ParentRoot),
-		"blob_count":        len(blResponse.Blobs),
-	}).Info("Preparing action for block and blobs")
 
 	slotAction, err := b.getSlotAction(uint64(blResponse.Block.Slot))
 	if err != nil {
@@ -306,6 +300,19 @@ func (b *Blobber) executeSlotActions(trigger_cl *beacon_client.BeaconClient, blR
 	}
 	if slotAction == nil {
 		panic("slot action is nil")
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"slot":              blResponse.Block.Slot,
+		"block_root":        fmt.Sprintf("%x", blockRoot),
+		"parent_block_root": fmt.Sprintf("%x", blResponse.Block.ParentRoot),
+		"blob_count":        len(blResponse.Blobs),
+		"action_name":       slotAction.Name(),
+	}).Info("Preparing action for block and blobs")
+
+	slotActionFields := logrus.Fields(slotAction.Fields())
+	if len(slotActionFields) > 0 {
+		logrus.WithFields(slotActionFields).Info("Action configuration")
 	}
 
 	testPeerCount := slotAction.GetTestPeerCount()

--- a/common/blob_record.go
+++ b/common/blob_record.go
@@ -1,0 +1,62 @@
+package common
+
+import (
+	"sync"
+
+	beacon_common "github.com/protolambda/zrnt/eth2/beacon/common"
+	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+)
+
+type BlobRecord struct {
+	sync.RWMutex
+	record map[beacon_common.Slot][]beacon_common.KZGCommitment
+}
+
+func NewBlobRecord() *BlobRecord {
+	return &BlobRecord{
+		record: make(map[beacon_common.Slot][]beacon_common.KZGCommitment),
+	}
+}
+
+func (br *BlobRecord) Add(slot beacon_common.Slot, blobSidecars ...*eth.BlobSidecar) {
+	br.Lock()
+	defer br.Unlock()
+	for _, blobSidecar := range blobSidecars {
+		var kzg beacon_common.KZGCommitment
+		copy(kzg[:], blobSidecar.KzgCommitment)
+		br.record[slot] = append(br.record[slot], kzg)
+	}
+}
+
+func (br *BlobRecord) GetSlots() []beacon_common.Slot {
+	br.RLock()
+	defer br.RUnlock()
+	var slots []beacon_common.Slot
+	for slot := range br.record {
+		slots = append(slots, slot)
+	}
+	return slots
+}
+
+func GetAllSlots(brAll ...*BlobRecord) []beacon_common.Slot {
+	slots := make(map[beacon_common.Slot]struct{})
+	for _, br := range brAll {
+		br.RLock()
+		for slot := range br.record {
+			slots[slot] = struct{}{}
+		}
+		br.RUnlock()
+	}
+
+	var slotsSlice []beacon_common.Slot
+	for slot := range slots {
+		slotsSlice = append(slotsSlice, slot)
+	}
+	return slotsSlice
+}
+
+func (br *BlobRecord) Get(slot beacon_common.Slot) []beacon_common.KZGCommitment {
+	br.RLock()
+	defer br.RUnlock()
+	return br.record[slot]
+}

--- a/slot_actions/helpers.go
+++ b/slot_actions/helpers.go
@@ -1,0 +1,115 @@
+package slot_actions
+
+import (
+	"sync"
+
+	"github.com/marioevz/blobber/p2p"
+	"github.com/pkg/errors"
+	blsu "github.com/protolambda/bls12-381-util"
+	beacon_common "github.com/protolambda/zrnt/eth2/beacon/common"
+	"github.com/protolambda/ztyp/tree"
+	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+)
+
+func SignBlock(block *eth.BeaconBlockDeneb, beaconBlockDomain beacon_common.BLSDomain, proposerKey *[32]byte) (*eth.SignedBeaconBlockDeneb, error) {
+	blockHTR, err := block.HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get block hash tree root")
+	}
+
+	signingRoot := beacon_common.ComputeSigningRoot(
+		tree.Root(blockHTR),
+		beaconBlockDomain,
+	)
+
+	sk := new(blsu.SecretKey)
+	sk.Deserialize(proposerKey)
+	signature := blsu.Sign(sk, signingRoot[:]).Serialize()
+	signedBlock := eth.SignedBeaconBlockDeneb{}
+	signedBlock.Block = block
+	signedBlock.Signature = signature[:]
+	return &signedBlock, nil
+}
+
+func SignBlob(blob *eth.BlobSidecar, blobSidecarDomain beacon_common.BLSDomain, proposerKey *[32]byte) (*eth.SignedBlobSidecar, error) {
+	blobHTR, err := blob.HashTreeRoot()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get block hash tree root")
+	}
+
+	signingRoot := beacon_common.ComputeSigningRoot(
+		tree.Root(blobHTR),
+		blobSidecarDomain,
+	)
+
+	sk := new(blsu.SecretKey)
+	sk.Deserialize(proposerKey)
+	signature := blsu.Sign(sk, signingRoot[:]).Serialize()
+	signedBlob := eth.SignedBlobSidecar{}
+	signedBlob.Message = blob
+	signedBlob.Signature = signature[:]
+	return &signedBlob, nil
+}
+
+func SignBlobs(blobs []*eth.BlobSidecar, blobSidecarDomain beacon_common.BLSDomain, proposerKey *[32]byte) ([]*eth.SignedBlobSidecar, error) {
+	signedBlobs := make([]*eth.SignedBlobSidecar, len(blobs))
+	for i, blob := range blobs {
+		signedBlob, err := SignBlob(blob, blobSidecarDomain, proposerKey)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to sign blob")
+		}
+		signedBlobs[i] = signedBlob
+	}
+	return signedBlobs, nil
+}
+
+func CopyBlobs(blobs []*eth.BlobSidecar) ([]*eth.BlobSidecar, error) {
+	copiedBlobs := make([]*eth.BlobSidecar, len(blobs))
+	for i, blob := range blobs {
+		copiedBlob := &eth.BlobSidecar{
+			BlockRoot:       blob.BlockRoot,
+			Index:           blob.Index,
+			Slot:            blob.Slot,
+			BlockParentRoot: blob.BlockParentRoot,
+			ProposerIndex:   blob.ProposerIndex,
+			Blob:            blob.Blob,
+			KzgCommitment:   blob.KzgCommitment,
+			KzgProof:        blob.KzgProof,
+		}
+		copiedBlobs[i] = copiedBlob
+	}
+	return copiedBlobs, nil
+}
+
+func MultiPeerSignedBlobBroadcast(peers p2p.TestPeers, signedBlobsLists [][]*eth.SignedBlobSidecar) error {
+	if len(peers) != len(signedBlobsLists) {
+		return errors.New("peers and signedBlobsLists must have the same length")
+	}
+
+	wg := sync.WaitGroup{}
+	errs := make(chan error, len(peers))
+
+	broadcastBlobs := func(testPeer *p2p.TestPeer, signedBlobs []*eth.SignedBlobSidecar) {
+		defer wg.Done()
+		for i, signedBlob := range signedBlobs {
+			if err := testPeer.BroadcastSignedBlobSidecar(signedBlob, nil); err != nil {
+				errs <- errors.Wrapf(err, "failed to broadcast signed blob %d", i)
+				return
+			}
+		}
+	}
+
+	for i, testPeer := range peers {
+		wg.Add(1)
+		go broadcastBlobs(testPeer, signedBlobsLists[i])
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		return err
+	}
+
+	return nil
+}

--- a/slot_actions/slot_actions.go
+++ b/slot_actions/slot_actions.go
@@ -18,6 +18,8 @@ import (
 const MAX_BLOBS_PER_BLOCK = 6
 
 type SlotAction interface {
+	Name() string
+	Fields() map[string]interface{}
 	GetTestPeerCount() int
 	Execute(
 		testPeers p2p.TestPeers,
@@ -68,6 +70,14 @@ func UnmarshallSlotAction(data []byte) (SlotAction, error) {
 
 type Default struct{}
 
+func (s Default) Name() string {
+	return "Default"
+}
+
+func (s Default) Fields() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
 func (s Default) GetTestPeerCount() int {
 	// By default we only create 1 test p2p and it's connected to all peers
 	return 1
@@ -108,6 +118,14 @@ type BroadcastBlobsBeforeBlock struct {
 	Default
 }
 
+func (s BroadcastBlobsBeforeBlock) Name() string {
+	return "Broadcast blobs before block"
+}
+
+func (s BroadcastBlobsBeforeBlock) Fields() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
 func (s BroadcastBlobsBeforeBlock) Execute(
 	testPeers p2p.TestPeers,
 	beaconBlock *eth.BeaconBlockDeneb,
@@ -142,6 +160,16 @@ func (s BroadcastBlobsBeforeBlock) Execute(
 type BlobGossipDelay struct {
 	Default
 	DelayMilliseconds int `json:"delay_milliseconds"`
+}
+
+func (s BlobGossipDelay) Name() string {
+	return "Blob gossip delay"
+}
+
+func (s BlobGossipDelay) Fields() map[string]interface{} {
+	return map[string]interface{}{
+		"delay_milliseconds": s.DelayMilliseconds,
+	}
 }
 
 func (s BlobGossipDelay) Execute(
@@ -191,6 +219,22 @@ type ExtraBlobs struct {
 	DelayMilliseconds       int  `json:"delay_milliseconds"`
 	BroadcastBlockFirst     bool `json:"broadcast_block_last"`
 	BroadcastExtraBlobFirst bool `json:"broadcast_extra_blob_last"`
+}
+
+func (s ExtraBlobs) Name() string {
+	return "Extra blobs"
+}
+
+func (s ExtraBlobs) Fields() map[string]interface{} {
+	return map[string]interface{}{
+		"incorrect_kzg_commitment":   s.IncorrectKZGCommitment,
+		"incorrect_kzg_proof":        s.IncorrectKZGProof,
+		"incorrect_block_root":       s.IncorrectBlockRoot,
+		"incorrect_signature":        s.IncorrectSignature,
+		"delay_milliseconds":         s.DelayMilliseconds,
+		"broadcast_block_first":      s.BroadcastBlockFirst,
+		"broadcast_extra_blob_first": s.BroadcastExtraBlobFirst,
+	}
 }
 
 func FillSidecarWithRandomBlob(sidecar *eth.BlobSidecar) error {
@@ -337,6 +381,18 @@ type ConflictingBlobs struct {
 	AlternateBlobRecipients     bool `json:"alternate_blob_recipients"`
 }
 
+func (s ConflictingBlobs) Name() string {
+	return "Conflicting blobs"
+}
+
+func (s ConflictingBlobs) Fields() map[string]interface{} {
+	return map[string]interface{}{
+		"conflicting_blobs_count":        s.ConflictingBlobsCount,
+		"random_conflicting_blobs_count": s.RandomConflictingBlobsCount,
+		"alternate_blob_recipients":      s.AlternateBlobRecipients,
+	}
+}
+
 func (s ConflictingBlobs) GetTestPeerCount() int {
 	// We are going to send two conflicting blobs through two different test p2p connections
 	return 2
@@ -436,6 +492,16 @@ func (s ConflictingBlobs) Execute(
 type SwapBlobs struct {
 	Default
 	SplitNetwork bool `json:"split_network"`
+}
+
+func (s SwapBlobs) Name() string {
+	return "Swap blobs"
+}
+
+func (s SwapBlobs) Fields() map[string]interface{} {
+	return map[string]interface{}{
+		"split_network": s.SplitNetwork,
+	}
 }
 
 func (s SwapBlobs) GetTestPeerCount() int {


### PR DESCRIPTION
## Changes Included
- Add an incorrect-index-blob slot action, which sends blob sidecars of KZG commitments that are actually included in the block, but the indexes of the sidecars are swapped with respect to the order they appear in the block
- Print the slot action being executed each slot to the logs
- Create a blob record of the blobs that must be included in the chain and a separate record of the ones that must not, the classification is done by each slot action.