### PR TITLE
fix: Equivocating block creation on long graffiti

### DIFF
--- a/slot_actions/slot_actions.go
+++ b/slot_actions/slot_actions.go
@@ -296,12 +296,12 @@ func (s EquivocatingBlockHeaderInBlobs) Description() string {
 	- Generate the sidecars out of the equivocating signed block only`)
 	if s.BroadcastBlobsFirst {
 		desc += dedent.Dedent(`
-		- Broadcast the blob sidecars
-		- Broadcast the first signed block only`)
+		- Broadcast the blob sidecars with the equivocating block header
+		- Broadcast the original signed block only`)
 	} else {
 		desc += dedent.Dedent(`
-		- Broadcast the first signed block only
-		- Broadcast the blob sidecars`)
+		- Broadcast the original signed block only
+		- Broadcast the blob sidecars with the equivocating block header`)
 	}
 	return desc
 }


### PR DESCRIPTION
Fixes equivocating block creation when the graffiti to be added is too long.

Fixes the last two of the failing hive tests for lighthouse, which were failing because the block was being imported, because both blocks, the original and the "equivocating", were identical.