### PR TITLE
fix: Equivocating Block Slot Action

### DIFF
--- a/slot_actions/slot_actions_test.go
+++ b/slot_actions/slot_actions_test.go
@@ -78,18 +78,14 @@ func TestSlotActionsJsonParsing(t *testing.T) {
 	}
 
 	jsonString = `{
-		"name": "equivocating_block",
+		"name": "invalid_equivocating_block",
 		"correct_block_delay_milliseconds": 1000
 	}`
 	act, err = slot_actions.UnmarshallSlotAction([]byte(jsonString))
 	if err != nil {
 		t.Fatalf("UnmarshallSlotAction() error = %v", err)
 	}
-	if actCast, ok := act.(*slot_actions.EquivocatingBlock); !ok {
+	if _, ok := act.(*slot_actions.InvalidEquivocatingBlock); !ok {
 		t.Fatalf("UnmarshallSlotAction() wrong type = %t", act)
-	} else {
-		if actCast.CorrectBlockDelayMilliseconds != 1000 {
-			t.Fatalf("UnmarshallSlotAction() correct_block_delay_milliseconds = %d", actCast.CorrectBlockDelayMilliseconds)
-		}
 	}
 }


### PR DESCRIPTION
Fixes equivocating block slot action by sending the original/valid block to one peer and the equivocating/invalid block to another one.

Clients were rejecting the second valid block due to it being a slashable offense and chain had trouble progressing if the slot action was executed each slot (unrealistic scenario).

If the valid block is sent to at least one peer, the chain can proceed without issues.

This also changes the name of the slot action from `equivocating_block` to `invalid_equivocating_block`, since the graffiti modification does indeed make the state root invalid.