### PR TITLE
Add basic api for managing blobber action & frequency

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/gorilla/mux"
+)
+
+type BlobberApi struct {
+	host string
+	port int
+
+	srv    *http.Server
+	cancel context.CancelFunc
+}
+
+type ApiHandlerCallback func(request *http.Request, body []byte) (interface{}, error)
+
+func NewBlobberApi(
+	ctx context.Context,
+	host string,
+	port int,
+	apiHandlerCallbacks map[string]ApiHandlerCallback,
+) (*BlobberApi, error) {
+	api := &BlobberApi{
+		host: host,
+		port: port,
+	}
+
+	router := mux.NewRouter()
+
+	for method, callback := range apiHandlerCallbacks {
+		router.HandleFunc(method, api.proxyHandler(callback))
+	}
+
+	api.srv = &http.Server{
+		Handler: router,
+		Addr:    fmt.Sprintf("%s:%d", host, port),
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	go func() {
+		if err := api.Start(ctx); err != nil && err != context.Canceled {
+			panic(err)
+		}
+	}()
+	api.cancel = cancel
+
+	return api, nil
+}
+
+func (p *BlobberApi) Port() int {
+	return p.port
+}
+
+func (p *BlobberApi) Address() string {
+	return fmt.Sprintf("http://%s:%d", p.host, p.port)
+}
+
+func (v *BlobberApi) proxyHandler(callback ApiHandlerCallback) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		// we need to buffer the body if we want to read it here and send it
+		// in the request.
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// you can reassign the body if you need to parse it as multipart
+		r.Body = io.NopCloser(bytes.NewReader(body))
+
+		rspData, err := callback(r, body)
+		if err != nil {
+			logrus.WithError(err).Error("Could not execute api callback")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		if rspData != nil {
+			w.Header().Set("Content-Type", "application/json")
+
+			err := json.NewEncoder(w).Encode(rspData)
+			if err != nil {
+				logrus.WithError(err).Error("error encoding api response")
+				http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			}
+		}
+	}
+}
+
+func (p *BlobberApi) Cancel() error {
+	if p.cancel != nil {
+		p.cancel()
+	}
+	return nil
+}
+
+// Start a proxy server.
+func (p *BlobberApi) Start(ctx context.Context) error {
+	p.srv.BaseContext = func(listener net.Listener) context.Context {
+		return ctx
+	}
+
+	fields := logrus.Fields{
+		"package":            "api",
+		"port":               p.port,
+		"listening_endpoint": p.Address(),
+	}
+	logrus.WithFields(fields).Info("API now listening")
+	go func() {
+		if err := p.srv.ListenAndServe(); err != nil {
+			logrus.WithFields(logrus.Fields{
+				"package": "api",
+			}).Error(err)
+		}
+	}()
+	for {
+		<-ctx.Done()
+		return p.srv.Shutdown(ctx)
+	}
+}

--- a/cmd/blobber.go
+++ b/cmd/blobber.go
@@ -65,6 +65,7 @@ func main() {
 		maxDevP2PSessionReuses            int
 		blobberID                         uint64
 		unsafeMode                        bool
+		apiPort                           int
 	)
 
 	flag.Var(
@@ -161,6 +162,12 @@ func main() {
 		false,
 		"Enable unsafe mode, only use this if you know what you're doing and never attempt to run this tool on mainnet.",
 	)
+	flag.IntVar(
+		&apiPort,
+		"api-port",
+		0,
+		"Port number for the blobber api. 0 means disable blobber api.",
+	)
 
 	err := flag.CommandLine.Parse(os.Args[1:])
 	if err != nil {
@@ -252,6 +259,7 @@ func main() {
 		config.WithProposalActionFrequency(uint64(proposalActionFrequency)),
 		config.WithMaxDevP2PSessionReuses(maxDevP2PSessionReuses),
 		config.WithLogLevel(logLevel),
+		config.WithApiPort(apiPort),
 	}
 
 	if validatorKeyFilePath != "" && validatorKeyFolderPath != "" {

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 
 	ID                           uint64
 	Port                         int
+	ApiPort                      int
 	ProxiesPortStart             int
 	Host                         string
 	Spec                         *beacon.Spec
@@ -291,5 +292,17 @@ func WithAlwaysErrorValidatorResponse() Option {
 			return nil
 		},
 		description: "WithAlwaysErrorValidatorResponse()",
+	}
+}
+
+func WithApiPort(port int) Option {
+	return Option{
+		apply: func(cfg *Config) error {
+			cfg.Lock()
+			defer cfg.Unlock()
+			cfg.ApiPort = port
+			return nil
+		},
+		description: fmt.Sprintf("WithApiPort(%d)", port),
 	}
 }


### PR DESCRIPTION
This is a WIP PR.

This PR Adds:
* [x] A basic API that allows reading/writing the ProposalAction & ProposalActionFrequency
* [ ] A basic API to read blobber-build block roots
* [ ] A jobs API that allows setting a action that is executed once (request should block till the action is executed)